### PR TITLE
isolate small terms (<5 chars)

### DIFF
--- a/src/file-content.js
+++ b/src/file-content.js
@@ -1,14 +1,20 @@
 const fs = require('fs');
 
 function checkFileForPhrase(file, phrase) {
+    // if the phrase is small (<5 chars) don't match it inside other words
+    var term = phrase
+    if (term.length < 5)
+        term = `[^a-z]${term}[^a-z]`;
+    // build the regular expression
+    var r = new RegExp(term,"ig");
 
     var lines = [];
     var content = fs.readFileSync(file, 'utf-8').toString().split("\n");
     content.forEach((line, index) => {
-        if(line.match(phrase)) {
+        if(line.match(r)) {
             var match = {
                 file: file,
-                number: index,
+                number: index+1,
                 content: line
             }
             lines.push(match);

--- a/tests/data/sample.md
+++ b/tests/data/sample.md
@@ -11,3 +11,6 @@ Add a breakpoint anywhere and you can start debugging.
 This is a sentence that uses he and she, this will be excluded during debug since we added them to the INPUT_EXCLUDETERMS param.
 
 Here is another that uses blacklist, which is not a good thing.
+
+"Her" by itself should be matched.
+But used in "Another" it wont cause an issue.


### PR DESCRIPTION
Checked that small terms (with less than 5 chars) are isolated (not surrounded by [a-z]).

Added two lines to add local testing with "Her"