### PR TITLE
Removed git show filter to avoid empty list errors

### DIFF
--- a/src/read-files.js
+++ b/src/read-files.js
@@ -37,7 +37,7 @@ function getFilesFromLastCommit(exclusions) {
     logger.debug(`git commit: ${commit.toString().trim()}`);
     var fetch = execSync(`git fetch -q --no-tags --no-recurse-submodules --depth=2 origin +${commit.toString().trim()}:refs/remotes/origin/${branch.toString().trim()}`);
     logger.debug(`git fetch: +${commit.toString().trim()}:refs/remotes/origin/${branch.toString().trim()}\n${fetch.toString().trim()}`);
-    var output = execSync('git show --format= --name-only --diff-filter=AM');
+    var output = execSync('git show --format= --name-only --diff-filter=d');
     logger.debug(`git show: \n${output.toString().trim()}`);
     var files = output.toString().trim().split("\n");
     var includedFiles = []


### PR DESCRIPTION
Any filtering on `git show` can result in an empty list of changed files, and then a failure of the check. To include more types of commits, the only _ignored_ files will be deleted files (hence the lower-case `d`).
Addresses Issue #31 